### PR TITLE
Two small fixes

### DIFF
--- a/feed2maildir/converter.py
+++ b/feed2maildir/converter.py
@@ -146,7 +146,7 @@ Link: {}
             fullname = maildir + mdir
             if not os.access(fullname, os.W_OK):
                 try: # to make the maildirs
-                    os.mkdir(fullname)
+                    os.makedirs(fullname)
                 except:
                     sys.exit('ERROR: accessing "{}" failed'.format(fullname))
 

--- a/feed2maildir/converter.py
+++ b/feed2maildir/converter.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import datetime
 import hashlib
 import json
@@ -175,9 +177,9 @@ Link: {}
                         # We only expect one to be found
                         pass
                 if not foundfile:
-                    print "WARNING: couldn't find {} in {}".format(
+                    print("WARNING: couldn't find {} in {}".format(
                         messagefile,
-                        self.name)
+                        self.name))
             time.sleep(1)
         return list(set(hashes))
 


### PR DESCRIPTION
I was playing around with this (really enjoyed your blog post, and walkthrough of the changes you made in _your_ fork! :) ), and to get it to run I needed to make a few small changes - 

- make the print statements all py3-compatible
- create maildirs recursively, which you need for something nested like e.g. `feeds/<feed>` - before this change, if `feeds/` didn't already exist, it would fail trying to create the child dir